### PR TITLE
fix: squash edition2021 bug and use nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@
 # failures.
 #
 # DON'T EDIT THIS!
+cargo-features = ["edition2021"]
+
 [package]
 name = "docker-starter-rust"
 version = "0.1.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN chmod +x /usr/local/bin/docker-explorer
 # Grab the dependencies and compile them as they dont change much
 COPY Cargo.toml /app/Cargo.toml
 COPY Cargo.lock /app/Cargo.lock
+COPY rust-toolchain.toml /app/rust-toolchain.toml
 
 RUN mkdir /app/src
 RUN echo 'fn main() { println!("Hello World!"); }' > /app/src/main.rs

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
Fix for the following error encountered when trying to run `mydocker` in Step 2:

```
=> ERROR [ 9/11] RUN cargo build --release --target-dir=/tmp/codecrafters-docker-target                                                                             151.5s
------
 > [ 9/11] RUN cargo build --release --target-dir=/tmp/codecrafters-docker-target:
#13 3.296     Updating crates.io index
#13 145.4  Downloading crates ...
#13 151.1   Downloaded matches v0.1.9
#13 151.2   Downloaded anyhow v1.0.59
#13 151.2   Downloaded tokio-util v0.3.1
#13 151.2   Downloaded pkg-config v0.3.25
#13 151.2   Downloaded foreign-types-shared v0.1.1
#13 151.2   Downloaded log v0.4.17
#13 151.2   Downloaded tinyvec v1.6.0
#13 151.3   Downloaded net2 v0.2.37
#13 151.3   Downloaded tracing v0.1.36
#13 151.3   Downloaded mime_guess v2.0.4
#13 151.3   Downloaded serde_urlencoded v0.7.1
#13 151.3   Downloaded indexmap v1.9.1
#13 151.3 error: failed to parse manifest at `/usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/indexmap-1.9.1/Cargo.toml`
#13 151.3 
#13 151.3 Caused by:
#13 151.3   feature `edition2021` is required
#13 151.3 
#13 151.3   this Cargo does not support nightly features, but if you
#13 151.3   switch to nightly channel you can add
#13 151.3   `cargo-features = ["edition2021"]` to enable this feature
------
executor failed running [/bin/sh -c cargo build --release --target-dir=/tmp/codecrafters-docker-target]: exit code: 101
```

Fixed by:
- Adding `edition2021` to the `cargo-features` list
- Switching rust version to nightly, needed to use `edition2021`